### PR TITLE
Fix dismissal of presentedViewController by other views

### DIFF
--- a/Sources/MCEmojiPicker/View/MCEmojiPickerRepresentableController.swift
+++ b/Sources/MCEmojiPicker/View/MCEmojiPickerRepresentableController.swift
@@ -123,10 +123,11 @@ public struct MCEmojiPickerRepresentableController: UIViewControllerRepresentabl
             context.coordinator.addPickerDismissingObserver()
             representableController.present(emojiPicker, animated: true)
         case false:
-            if representableController.presentedViewController is MCEmojiPickerViewController {
+            if representableController.presentedViewController is MCEmojiPickerViewController && context.coordinator.isPresented {
                 representableController.presentedViewController?.dismiss(animated: true)
             }
         }
+        context.coordinator.isPresented = isPresented
     }
 }
 
@@ -137,6 +138,7 @@ extension MCEmojiPickerRepresentableController {
     public class Coordinator: NSObject, MCEmojiPickerDelegate {
         
         public var isNewEmojiSet = false
+        public var isPresented = false
         
         private var representableController: MCEmojiPickerRepresentableController
         


### PR DESCRIPTION
Ran into the issue in https://github.com/izyumkin/MCEmojiPicker/issues/18 . 

I don't know if this is the right approach but from debugging I see that when this component is used in a loop, the presentedViewController is shared across the instances. As the loop calls the update function on each instance, the instances that have isPresented set to false will dismiss the modal. The fix just sets the state on the coordinator, which is not shared. 